### PR TITLE
feat: Add `containsSame()`, `containsAll()`, `containsNone()` methods to class `Microplate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v4.4.0
+
+### Added
+
+- Add `containsSame()`, `containsAll()`, `containsNone()` methods to class `Microplate`
+
 ## v4.3.2
 
 ### Fixed

--- a/src/Microplate.php
+++ b/src/Microplate.php
@@ -136,4 +136,39 @@ final class Microplate extends AbstractMicroplate
 
         return Coordinate::fromString($coordinateString, $this->coordinateSystem);
     }
+
+    /**
+     * @param Collection<array-key, TWell> $wells
+     */
+    public function containsAll(Collection $wells): bool
+    {
+        return $wells
+            ->diff($this->filledWells())
+            ->isEmpty();
+    }
+
+    /**
+     * @param Collection<array-key, TWell> $wells
+     */
+    public function containsNone(Collection $wells): bool
+    {
+        return $this->filledWells()
+            ->intersect($wells)
+            ->isEmpty();
+    }
+
+    /**
+     * @param Collection<array-key, TWell> $wells
+     */
+    public function containsSame(Collection $wells): bool
+    {
+        $firstDiffEmpty = $wells->diff($this->wells)
+            ->isEmpty();
+
+        $secondDiffEmpty = $this->filledWells()
+            ->diff($wells)
+            ->isEmpty();
+
+        return $firstDiffEmpty && $secondDiffEmpty;
+    }
 }

--- a/tests/Unit/MicroplateTest.php
+++ b/tests/Unit/MicroplateTest.php
@@ -224,4 +224,88 @@ final class MicroplateTest extends TestCase
     {
         return CoordinateTest::dataProvider12Well();
     }
+
+    public function testContainsAllTrueForSame(): void
+    {
+        $microplate = new Microplate(new CoordinateSystem12Well());
+        $microplate->addToNextFreeWell(1, FlowDirection::COLUMN());
+        $microplate->addToNextFreeWell(2, FlowDirection::COLUMN());
+
+        self::assertTrue($microplate->containsAll(new Collection([1, 2])));
+    }
+
+    public function testContainsAllTrueIfPlateHasAllAndMoreWells(): void
+    {
+        $microplate = new Microplate(new CoordinateSystem12Well());
+        $microplate->addToNextFreeWell(1, FlowDirection::COLUMN());
+        $microplate->addToNextFreeWell(2, FlowDirection::COLUMN());
+        $microplate->addToNextFreeWell(3, FlowDirection::COLUMN());
+
+        self::assertTrue($microplate->containsAll(new Collection([1, 2])));
+    }
+
+    public function testContainsAllFalseIfWellIsMissingOnPlate(): void
+    {
+        $microplate = new Microplate(new CoordinateSystem12Well());
+        $microplate->addToNextFreeWell(1, FlowDirection::COLUMN());
+        $microplate->addToNextFreeWell(2, FlowDirection::COLUMN());
+
+        self::assertFalse($microplate->containsAll(new Collection([1, 2, 3])));
+    }
+
+    public function testContainsNoneTrue(): void
+    {
+        $microplate = new Microplate(new CoordinateSystem12Well());
+        $microplate->addToNextFreeWell(1, FlowDirection::COLUMN());
+        $microplate->addToNextFreeWell(2, FlowDirection::COLUMN());
+
+        self::assertTrue($microplate->containsNone(new Collection([3, 4])));
+    }
+
+    public function testContainsNoneFalseForOneButNotAllValues(): void
+    {
+        $microplate = new Microplate(new CoordinateSystem12Well());
+        $microplate->addToNextFreeWell(1, FlowDirection::COLUMN());
+        $microplate->addToNextFreeWell(2, FlowDirection::COLUMN());
+
+        self::assertFalse($microplate->containsNone(new Collection([2, 4])));
+    }
+
+    public function testContainsNoneFalseForAllValues(): void
+    {
+        $microplate = new Microplate(new CoordinateSystem12Well());
+        $microplate->addToNextFreeWell(1, FlowDirection::COLUMN());
+        $microplate->addToNextFreeWell(2, FlowDirection::COLUMN());
+
+        self::assertFalse($microplate->containsNone(new Collection([1, 2])));
+    }
+
+    public function testContainsSameTrue(): void
+    {
+        $microplate = new Microplate(new CoordinateSystem12Well());
+        $microplate->addToNextFreeWell(1, FlowDirection::COLUMN());
+        $microplate->addToNextFreeWell(2, FlowDirection::COLUMN());
+
+        self::assertTrue($microplate->containsSame(new Collection([1, 2])));
+    }
+
+    public function testContainsSameFalseIfPlateHasOneMore(): void
+    {
+        $microplate = new Microplate(new CoordinateSystem12Well());
+        $microplate->addToNextFreeWell(1, FlowDirection::COLUMN());
+        $microplate->addToNextFreeWell(2, FlowDirection::COLUMN());
+        $microplate->addToNextFreeWell(3, FlowDirection::COLUMN());
+
+        self::assertFalse($microplate->containsSame(new Collection([1, 2])));
+    }
+
+    public function testContainsSameFalseIfPlateHasOneMissing(): void
+    {
+        $microplate = new Microplate(new CoordinateSystem12Well());
+        $microplate->addToNextFreeWell(1, FlowDirection::COLUMN());
+        $microplate->addToNextFreeWell(2, FlowDirection::COLUMN());
+
+        self::assertFalse($microplate->containsSame(new Collection([1, 2, 3])));
+    }
+
 }


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

<!-- Link to related issues this PR resolves, e.g. "Resolves #236"-->

**Changes**

- Add `containsSame()`, `containsAll()`, `containsNone()` methods to class `Microplate`
