### PR TITLE
feat: Add `isConsecutive()` method to `AbstractMicroplate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v5.2.0
+
+### Added
+
+- Add `isConsecutive()` method to `AbstractMicroplate`
+
 ## v5.1.0
 
 ### Changed

--- a/src/AbstractMicroplate.php
+++ b/src/AbstractMicroplate.php
@@ -141,7 +141,9 @@ abstract class AbstractMicroplate
     }
 
     /**
-     * If the wells are in a consecutive order.
+     * Are all filled wells placed in a single connected block without gaps between them?
+     *
+     * Returns `false` if all wells are empty.
      */
     public function isConsecutive(FlowDirection $flowDirection): bool
     {

--- a/src/AbstractMicroplate.php
+++ b/src/AbstractMicroplate.php
@@ -139,4 +139,20 @@ abstract class AbstractMicroplate
             Coordinate::fromString($coordinateString, $this->coordinateSystem)
         );
     }
+
+    /**
+     * If the wells are in a consecutive order.
+     */
+    public function isConsecutive(FlowDirection $flowDirection): bool
+    {
+        $positions = $this->filledWells()
+            /**
+             * @param TWell $content
+             */
+            ->map(
+                fn ($content, string $coordinateString): int => Coordinate::fromString($coordinateString, $this->coordinateSystem)->position($flowDirection)
+            );
+
+        return ($positions->max() - $positions->min() + 1) === $positions->count();
+    }
 }

--- a/tests/Unit/MicroplateTest.php
+++ b/tests/Unit/MicroplateTest.php
@@ -210,6 +210,48 @@ final class MicroplateTest extends TestCase
         $microplate->nextFreeWellCoordinate(FlowDirection::ROW());
     }
 
+    public function testIsConsecutiveForColumn(): void
+    {
+        $coordinateSystem = new CoordinateSystem96Well();
+        $microplate = new Microplate($coordinateSystem);
+
+        $data = [
+            'A1', 'B1', 'C1',
+        ];
+        foreach ($data as $wellData) {
+            $microplateCoordinate = Coordinate::fromString($wellData, $coordinateSystem);
+            $microplate->addWell($microplateCoordinate, 'test');
+        }
+
+        self::assertTrue($microplate->isConsecutive(FlowDirection::COLUMN()));
+        self::assertFalse($microplate->isConsecutive(FlowDirection::ROW()));
+
+        // is not consecutive anymore after adding a gap at E1
+        $microplate->addWell(Coordinate::fromString('E1', $coordinateSystem), 'test');
+        self::assertFalse($microplate->isConsecutive(FlowDirection::COLUMN()));
+    }
+
+    public function testIsConsecutiveForRow(): void
+    {
+        $coordinateSystem = new CoordinateSystem96Well();
+        $microplate = new Microplate($coordinateSystem);
+
+        $data = [
+            'A1', 'A2', 'A3',
+        ];
+        foreach ($data as $wellData) {
+            $microplateCoordinate = Coordinate::fromString($wellData, $coordinateSystem);
+            $microplate->addWell($microplateCoordinate, 'test');
+        }
+
+        self::assertTrue($microplate->isConsecutive(FlowDirection::ROW()));
+        self::assertFalse($microplate->isConsecutive(FlowDirection::COLUMN()));
+
+        // is not consecutive anymore after adding a gap at A5
+        $microplate->addWell(Coordinate::fromString('A5', $coordinateSystem), 'test');
+        self::assertFalse($microplate->isConsecutive(FlowDirection::ROW()));
+    }
+
     /**
      * @return list<array{row: string, column: int, rowFlowPosition: int, columnFlowPosition: int}>
      */

--- a/tests/Unit/MicroplateTest.php
+++ b/tests/Unit/MicroplateTest.php
@@ -252,6 +252,28 @@ final class MicroplateTest extends TestCase
         self::assertFalse($microplate->isConsecutive(FlowDirection::ROW()));
     }
 
+    public function testIsConsecutiveForEmptyPlate(): void
+    {
+        $coordinateSystem = new CoordinateSystem96Well();
+        $microplate = new Microplate($coordinateSystem);
+
+        self::assertFalse($microplate->isConsecutive(FlowDirection::ROW()));
+        self::assertFalse($microplate->isConsecutive(FlowDirection::COLUMN()));
+    }
+
+    public function testIsConsecutiveForFullPlate(): void
+    {
+        $coordinateSystem = new CoordinateSystem96Well();
+        $microplate = new Microplate($coordinateSystem);
+
+        foreach ($coordinateSystem->all() as $coordinate) {
+            $microplate->addWell($coordinate, 'test');
+        }
+
+        self::assertTrue($microplate->isConsecutive(FlowDirection::ROW()));
+        self::assertTrue($microplate->isConsecutive(FlowDirection::COLUMN()));
+    }
+
     /**
      * @return list<array{row: string, column: int, rowFlowPosition: int, columnFlowPosition: int}>
      */


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

**Changes**

- Add `isConsecutive()` method to `AbstractMicroplate`
